### PR TITLE
test: don't involve examples/ directory

### DIFF
--- a/examples/errors.tera
+++ b/examples/errors.tera
@@ -1,5 +1,0 @@
-a: b
----
-this file is total junk
-{{ nonexistent }}
-{{ these words dont work }}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -107,7 +107,7 @@ mod sad_path {
     #[test]
     fn invalid_flavor() {
         let mut cmd = Command::cargo_bin("whiskers").expect("binary exists");
-        cmd.arg("examples/demo/input.tera")
+        cmd.arg("tests/fixtures/single/single.tera")
             .args(["--flavor", "invalid"]);
         cmd.assert().failure().stderr(predicate::str::contains(
             "error: invalid value 'invalid' for '--flavor <FLAVOR>'",
@@ -117,7 +117,7 @@ mod sad_path {
     #[test]
     fn template_contains_invalid_syntax() {
         let mut cmd = Command::cargo_bin("whiskers").expect("binary exists");
-        cmd.arg("examples/errors.tera").args(["-f", "mocha"]);
+        cmd.arg("tests/fixtures/errors.tera").args(["-f", "mocha"]);
         cmd.assert()
             .failure()
             .stderr(predicate::str::contains("Error: Template is invalid"));

--- a/tests/fixtures/errors.tera
+++ b/tests/fixtures/errors.tera
@@ -1,0 +1,5 @@
+a: b
+---
+this file is total junk
+{{ nonexistent }}
+{{ these words dont work }}


### PR DESCRIPTION
As discussed in Discord, the tests currently fail without the existence of the `examples/` directory. This moves the two remaining tests over to `fixtures/` instead.