### PR TITLE
build(nix): do not include examples dir

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -11,7 +11,6 @@ rustPlatform.buildRustPackage {
         ./Cargo.lock
         ./src
         ./tests
-        ./examples
         ./LICENSE
       ]
     );

--- a/default.nix
+++ b/default.nix
@@ -1,7 +1,10 @@
 { lib, rustPlatform }:
+let
+  toml = (lib.importTOML ./Cargo.toml).package;
+in
 rustPlatform.buildRustPackage {
   pname = "catppuccin-whiskers";
-  inherit ((lib.importTOML ./Cargo.toml).package) version;
+  inherit (toml) version;
 
   src = lib.fileset.toSource {
     root = ./.;
@@ -19,8 +22,7 @@ rustPlatform.buildRustPackage {
   cargoLock.lockFile = ./Cargo.lock;
 
   meta = {
-    homepage = "https://github.com/catppuccin/whiskers";
-    description = "😾 Soothing port creation tool for the high-spirited!";
+    inherit (toml) homepage description;
     license = lib.licenses.mit;
     mainProgram = "whiskers";
   };

--- a/shell.nix
+++ b/shell.nix
@@ -1,15 +1,13 @@
 { callPackage, toolchain }:
 let
   mainPkg = callPackage ./default.nix { };
-  toolchainWithComponents = (
-    toolchain.stable.latest.default.override {
-      extensions = [
-        "rustfmt"
-        "rust-analyzer"
-        "clippy"
-      ];
-    }
-  );
+  toolchainWithComponents = toolchain.stable.latest.default.override {
+    extensions = [
+      "rustfmt"
+      "rust-analyzer"
+      "clippy"
+    ];
+  };
 in
 mainPkg.overrideAttrs (oa: {
   nativeBuildInputs = [ toolchainWithComponents ] ++ (oa.nativeBuildInputs or [ ]);


### PR DESCRIPTION
Following https://github.com/catppuccin/whiskers/pull/6, we don't need to import the examples dir for the build process. 
Also included some misc cleanup stuff.