### PR TITLE
fix(check): wait until all diffs are shown before exiting

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -498,7 +498,9 @@ fn render_single_output(
         .context("Template render failed")?;
 
     if let Some(path) = check {
-        check_result_with_file(&path, &result).context("Check mode failed")?;
+        if matches!(check_result_with_file(&path, &result).context("Check mode failed")?, CheckResult::Fail) {
+            std::process::exit(1);
+        }
     } else if let Some(filename) = filename {
         write_template(dry_run, &filename, result)?;
     } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -581,6 +581,7 @@ fn maybe_create_parents(filename: &Path) -> anyhow::Result<()> {
     Ok(())
 }
 
+#[must_use]
 enum CheckResult {
     Pass,
     Fail,

--- a/src/main.rs
+++ b/src/main.rs
@@ -522,6 +522,7 @@ fn render_multi_output(
         .map(|(key, iterable)| iterable.into_iter().map(move |v| (key.clone(), v)))
         .multi_cartesian_product()
         .collect::<Vec<_>>();
+    let mut check_results: Vec<CheckResult> = Vec::with_capacity(iterables.len());
 
     for iterable in iterables {
         let mut ctx = ctx.clone();
@@ -549,10 +550,15 @@ fn render_multi_output(
             .context("Filename template render failed")?;
 
         if args.check.is_some() {
-            check_result_with_file(&filename, &result).context("Check mode failed")?;
+            check_results
+                .push(check_result_with_file(&filename, &result).context("Check mode failed")?);
         } else {
             write_template(args.dry_run, &filename, result)?;
         }
+    }
+
+    if check_results.iter().any(|r| matches!(r, CheckResult::Fail)) {
+        std::process::exit(1);
     }
 
     Ok(())
@@ -570,7 +576,12 @@ fn maybe_create_parents(filename: &Path) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn check_result_with_file<P>(path: &P, result: &str) -> anyhow::Result<()>
+enum CheckResult {
+    Pass,
+    Fail,
+}
+
+fn check_result_with_file<P>(path: &P, result: &str) -> anyhow::Result<CheckResult>
 where
     P: AsRef<Path>,
 {
@@ -581,12 +592,13 @@ where
             path.display()
         )
     })?;
-    if *result != expected {
+    if *result == expected {
+        Ok(CheckResult::Pass)
+    } else {
         eprintln!("Output does not match {}", path.display());
         invoke_difftool(result, path)?;
-        std::process::exit(1);
+        Ok(CheckResult::Fail)
     }
-    Ok(())
 }
 
 fn invoke_difftool<P>(actual: &str, expected_path: P) -> anyhow::Result<()>

--- a/src/main.rs
+++ b/src/main.rs
@@ -498,7 +498,10 @@ fn render_single_output(
         .context("Template render failed")?;
 
     if let Some(path) = check {
-        if matches!(check_result_with_file(&path, &result).context("Check mode failed")?, CheckResult::Fail) {
+        if matches!(
+            check_result_with_file(&path, &result).context("Check mode failed")?,
+            CheckResult::Fail
+        ) {
             std::process::exit(1);
         }
     } else if let Some(filename) = filename {


### PR DESCRIPTION


Currently, the `--check` command exits after the first invocation of the difftool which means that diffs for multiple files are not shown, which is an error for ports that generate multiple files:

You can see this behaviour in action below where 2 files have been edited but only one diff is shown:
![image](https://github.com/user-attachments/assets/2cca2b83-7aea-4c26-b2c5-e71e6356d2e4)

This PR updates the implementation of the check command to wait till after all the diffs are shown and only exit afterwards. 

Now, you can see that it works as expected:

![image](https://github.com/user-attachments/assets/5cc51b91-501d-4fef-897e-5477cc41e33f)

I'm going to see a movie with a friend soon so just quickly mocked this up, feel more than free to edit the PR and optimise it more since I don't write much Rust these days. (I imagine we can move away from using a `Vec`)
