### PR TITLE
docs(README): remove migration notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,6 @@ Whiskers is a port creation helper tool that is custom-built for Catppuccin,
 allowing developers to define template files which the palette can be injected
 into.
 
-> [!IMPORTANT]
-> This repository has been migrated from
-> [catppuccin/toolbox](https://github.com/catppuccin/toolbox/tree/main/whiskers). To view releases
-> prior to [v2.3.0](https://github.com/catppuccin/whiskers/releases/tag/v2.3.0),
-> see the [releases from catppuccin/toolbox](https://github.com/catppuccin/toolbox/releases?q=whiskers&expanded=true).
-
 ## Installation
 
 You can install Whiskers using one of the methods below:


### PR DESCRIPTION
I kept meaning to remove this ever since we actually did migrate the
releases over, so people don't need to be directed to
`catppuccin/toolbox`.
