### PR TITLE
docs: fix wrong file name in quickstart

### DIFF
--- a/docs/src/content/docs/getting-started/quick-start.mdx
+++ b/docs/src/content/docs/getting-started/quick-start.mdx
@@ -98,7 +98,7 @@ This template will generate a file containing all the colors of a single flavor.
    ---
    ```
 
-1. Re-run the command from Step 3. and view the newly created `palette.md` file
+1. Re-run the command from Step 3. and view the newly created `flavor.md` file
    which should look like:
 
    ```markdown title="flavor.md"


### PR DESCRIPTION
Hi,

This is just a small PR to fix a filename as it might be confusing for newcomers