### PR TITLE
fix(templating): fully remove rgb_array

### DIFF
--- a/src/templating.rs
+++ b/src/templating.rs
@@ -112,11 +112,6 @@ pub fn all_functions() -> Vec<Function> {
             examples: vec![function_example!(css_hsla(color=red) => "hsla(347, 87%, 44%, 1.00)")],
         },
         Function {
-            name: "rgb_array".to_string(),
-            description: "Convert a color to an array of RGB values".to_string(),
-            examples: vec![function_example!(rgb_array(color=red) => "[210, 15, 57]")],
-        },
-        Function {
             name: "read_file".to_string(),
             description:
                 "Read and include the contents of a file, path is relative to the template file"
@@ -196,11 +191,6 @@ pub fn all_filters() -> Vec<Filter> {
             name: "css_hsla".to_string(),
             description: "Convert a color to an HSLA CSS string".to_string(),
             examples: vec![filter_example!(red | css_hsla => "hsla(347, 87%, 44%, 1.00)")],
-        },
-        Filter {
-            name: "rgb_array".to_string(),
-            description: "Convert a color to an array of RGB values".to_string(),
-            examples: vec![filter_example!(red | rgb_array => "[210, 15, 57]")],
         },
     ]
 }


### PR DESCRIPTION
Removes `rgb_array` from the `all_filters` and `all_functions` lists in `templating.rs`